### PR TITLE
mention csquotes package with enquote macro for quote formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,9 @@ sort w  & 0     &       & --    & \X    & 0 \\
 * Match opening and closing quotes using one or two single-opening
   (`‘` or `‘‘`) and single-closing (`’` or `’’`) quote characters.
   Do not use the keyboard's double quote symbol (`"`).
+  Alternatively you can use the `\enquote{}` macro from the `csquotes`
+  package, which will automatically set the right quotes for the
+  configure language and can handle nested quotes correctly.
 * Use the new local font style commands
   (e.g. `\texttt{}`, `\textsc{}`, or `\textbf{}`)
   rather than the old switches (e.g. `{\tt }`, `{\sc }`, `{\bf }`)


### PR DESCRIPTION
For quote formatting the `csquotes` package provides the very helpful `\enquote` macro. Using this automatically identifies the language set in the document (for example with `babel`) and sets the right quotes for the chosen language. It can also handle nested quotes (thus alternating between `` and ` for example) automatically.